### PR TITLE
Initial import of end-to-end mxnet-to-nnvm-tvm example using C++ SDK

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,98 @@
+---
+Language:        Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+BreakBeforeInheritanceComma: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+- Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,13 @@
 *.exe
 *.out
 *.app
+
+# CMake file
+_*/
+
+# clion
+.idea/
+
+# emacs files
+*~
+TAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,86 @@
+cmake_minimum_required(VERSION 3.2)
+project(tvm_cpp_test)
+
+include_directories(/dl/mxnet/3rdparty/tvm/3rdparty/dlpack/include)
+include_directories(/dl/mxnet/3rdparty/tvm/3rdparty/dmlc-core/include)
+include_directories(/dl/mxnet/3rdparty/tvm/include)
+
+function(print_cmake_vars)
+  get_cmake_property(_variableNames VARIABLES)
+  list (SORT _variableNames)
+  foreach (_variableName ${_variableNames})
+    message(STATUS "${_variableName}=${${_variableName}}")
+  endforeach()
+endfunction()
+
+# add include so that relative paths in the upstream tvm_runtime_pack.cc will work
+include_directories(/dl/mxnet/3rdparty/tvm/apps/howto_deploy)
+
+add_executable(
+  tvm_deploy_gpu_sample
+  tvm_deploy_gpu_sample.cpp
+
+  # Adopt tvm_runtime_pack.cc for local modifications
+  tvm_runtime_pack.cc
+  # This could eventually go back here:
+  #/dl/mxnet/3rdparty/tvm/apps/howto_deploy/tvm_runtime_pack.cc
+  )
+
+find_package(Threads REQUIRED)
+target_link_libraries(tvm_deploy_gpu_sample PUBLIC Threads::Threads ${CMAKE_DL_LIBS})
+
+option(TCT_USE_CPU "Use cpu runtime" OFF)
+if(TCT_USE_CPU)
+  # currently nothing is required
+  target_compile_definitions(tvm_deploy_gpu_sample PUBLIC TVM_CPU_RUNTIME=1)
+endif()
+
+option(TCT_USE_OPENGL "Use opengl runtime" OFF)
+if(TCT_USE_OPENGL)
+  find_package(OpenGL REQUIRED)
+  target_link_libraries(tvm_deploy_gpu_sample PUBLIC OpenGL::OpenGL)
+
+  find_package(glfw3)
+  target_link_libraries(tvm_deploy_gpu_sample PUBLIC glfw)
+
+  target_compile_definitions(tvm_deploy_gpu_sample PUBLIC TVM_OPENGL_RUNTIME=1)
+endif()
+
+option(TCT_USE_OPENCL "Use opencl runtime" OFF)
+if(TCT_USE_OPENCL)
+  find_package(OpenCL REQUIRED)
+  target_link_libraries(tvm_deploy_gpu_sample PUBLIC OpenCL::OpenCL)
+  target_compile_definitions(tvm_deploy_gpu_sample PUBLIC TVM_OPENCL_RUNTIME=1)
+endif()
+
+option(TCT_USE_VULKAN "Use vulkan runtime" OFF)
+if(TCT_USE_VULKAN)
+  find_package(Vulkan REQUIRED)
+  target_link_libraries(tvm_deploy_gpu_sample PUBLIC Vulkan::Vulkan)
+  target_compile_definitions(tvm_deploy_gpu_sample PUBLIC TVM_VULKAN_RUNTIME=1)
+endif()
+
+option(TCT_USE_CUDA "Use cuda runtime" OFF)
+if(TCT_USE_CUDA)
+  find_package(CUDA REQUIRED)
+  #print_cmake_vars()
+  target_compile_definitions(tvm_deploy_gpu_sample PUBLIC TVM_CUDA_RUNTIME=1)
+  target_include_directories(tvm_deploy_gpu_sample PUBLIC ${CUDA_INCLUDE_DIRS})
+  target_link_libraries(tvm_deploy_gpu_sample PUBLIC
+    ${CUDA_CUDA_LIBRARY}
+    ${CUDA_CUDART_LIBRARY}
+    ${CUDA_CURAND_LIBRARY})
+endif()
+
+option(TCT_USE_METAL "Use metal runtime" OFF)
+if(TCT_USE_METAL)
+  find_package(Metal REQUIRED)
+  target_link_libraries(tvm_deploy_gpu_sample PUBLIC Metal::Metal)
+  target_compile_definitions(tvm_deploy_gpu_sample PUBLIC TVM_METAL_RUNTIME=1)
+endif()
+
+option(TCT_USE_GRAPH_RUNTIME_DEBUG "use debug runtime" ON)
+target_compile_definitions(tvm_deploy_gpu_sample PUBLIC TVM_USE_GRAPH_RUNTIME_DEBUG=1)
+
+enable_testing()
+add_test(NAME tvm_deploy_gpu_sample COMMAND tvm_deploy_gpu_sample)

--- a/GraphRuntime.h
+++ b/GraphRuntime.h
@@ -1,0 +1,331 @@
+#ifndef __graph_runtime_h__
+#define __graph_runtime_h__
+
+#include <dmlc/json.h>
+#include <tvm/runtime/ndarray.h>
+
+using tvm::runtime::NDArray;
+
+/*
+
+  Here we borrow a partial implementation of GraphRuntime from here:
+
+  tvm/src/runtime/graph/graph_runtime.h
+
+  Since there doesn't seem to be a public hook to access the layer info
+  that is required for logging layer output at runtime.  In particular,
+  we need access to:
+
+  1) the number of layers : needed to iterate over all layers
+  2) the layer attributes : needed by to allocate DLTensor * if using debug_get_output
+
+  This info is all contained in private member variables of GraphRuntime after
+  loading the JSON graph, so we simply duplicate the parts we need here for
+  the C++ test and serialization.
+
+ */
+
+struct GraphRuntimePrivateStuff
+{
+    /*! \brief operator attributes about tvm op */
+    struct TVMOpParam
+    {
+        std::string func_name;
+        uint32_t num_inputs;
+        uint32_t num_outputs;
+        uint32_t flatten_data;
+    };
+
+    struct PoolEntry
+    {
+        size_t size;
+        int device_type;
+
+        PoolEntry(int s, int dev_type)
+            : size(s)
+            , device_type(dev_type)
+        {
+        }
+    };
+
+    // Node entry
+    struct NodeEntry
+    {
+        uint32_t node_id;
+        uint32_t index;
+        uint32_t version;
+
+        // JSON Loader
+        void Load(dmlc::JSONReader* reader)
+        {
+            reader->BeginArray();
+            CHECK(reader->NextArrayItem()) << "invalid json format";
+            reader->Read(&node_id);
+            CHECK(reader->NextArrayItem()) << "invalid json format";
+            reader->Read(&index);
+            if (reader->NextArrayItem())
+            {
+                reader->Read(&version);
+                CHECK(!reader->NextArrayItem()) << "invalid json format";
+            }
+            else
+            {
+                version = 0;
+            }
+        }
+    };
+
+    // Node
+    struct Node
+    {
+        // operator type in string
+        std::string op_type;
+        // name of the op
+        std::string name;
+        // parameters
+        TVMOpParam param;
+        // inputs
+        std::vector<NodeEntry> inputs;
+        // control deps
+        std::vector<uint32_t> control_deps;
+
+        // JSON Loader
+        void LoadAttrs(dmlc::JSONReader* reader, TVMOpParam* param)
+        {
+            int bitmask = 0;
+            std::string key, value;
+            reader->BeginObject();
+            while (reader->NextObjectItem(&key))
+            {
+                reader->Read(&value);
+                if (key == "func_name")
+                {
+                    param->func_name = value;
+                    bitmask |= 1;
+                }
+                else if (key == "num_inputs")
+                {
+                    param->num_inputs = strtoul(value.c_str(), nullptr, 10);
+                    bitmask |= 2;
+                }
+                else if (key == "num_outputs")
+                {
+                    param->num_outputs = strtoul(value.c_str(), nullptr, 10);
+                    bitmask |= 4;
+                }
+                else if (key == "flatten_data")
+                {
+                    param->flatten_data = strtoul(value.c_str(), nullptr, 10);
+                    bitmask |= 8;
+                }
+            }
+            CHECK_EQ(bitmask, 1 | 2 | 4 | 8) << "invalid format";
+        }
+
+        // JSON Loader
+        void Load(dmlc::JSONReader* reader)
+        {
+            reader->BeginObject();
+            int bitmask = 0;
+            std::string key;
+            while (reader->NextObjectItem(&key))
+            {
+                if (key == "op")
+                {
+                    reader->Read(&op_type);
+                    bitmask |= 1;
+                }
+                else if (key == "name")
+                {
+                    reader->Read(&name);
+                    bitmask |= 2;
+                }
+                else if (key == "inputs")
+                {
+                    reader->Read(&inputs);
+                    bitmask |= 4;
+                }
+                else if (key == "attr" || key == "attrs")
+                {
+                    this->LoadAttrs(reader, &param);
+                }
+                else if (key == "control_deps")
+                {
+                    reader->Read(&control_deps);
+                }
+                else
+                {
+                    LOG(FATAL) << "do not support key " << key;
+                }
+            }
+            CHECK_EQ(bitmask, 1 | 2 | 4) << "invalid format";
+        }
+    };
+
+    struct GraphAttr
+    {
+        size_t storage_num_not_alloctaed{ 0 };
+        std::vector<int> storage_id;
+        std::vector<int> device_index;
+        std::vector<std::string> dltype;
+        std::vector<std::vector<int64_t>> shape;
+
+        // The graph attribute fields.
+        void Load(dmlc::JSONReader* reader)
+        {
+            reader->BeginObject();
+            int bitmask = 0;
+            std::string key, type;
+            while (reader->NextObjectItem(&key))
+            {
+                if (key == "dltype")
+                {
+                    reader->BeginArray();
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&type);
+                    CHECK_EQ(type, "list_str");
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&dltype);
+                    CHECK(!reader->NextArrayItem());
+                    bitmask |= 1;
+                }
+                else if (key == "storage_id")
+                {
+                    reader->BeginArray();
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&type);
+                    CHECK_EQ(type, "list_int");
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&storage_id);
+                    CHECK(!reader->NextArrayItem());
+                    bitmask |= 2;
+                }
+                else if (key == "shape")
+                {
+                    reader->BeginArray();
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&type);
+                    CHECK_EQ(type, "list_shape");
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&shape);
+                    CHECK(!reader->NextArrayItem());
+                    bitmask |= 4;
+                }
+                else if (key == "device_index")
+                {
+                    reader->BeginArray();
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&type);
+                    CHECK_EQ(type, "list_int");
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&device_index);
+                    CHECK(!reader->NextArrayItem());
+                }
+                else
+                {
+                    reader->BeginArray();
+                    CHECK(reader->NextArrayItem());
+                    reader->Read(&type);
+                    if (type == "list_int")
+                    {
+                        CHECK(reader->NextArrayItem());
+                        std::vector<int> temp;
+                        reader->Read(&temp);
+                    }
+                    else if (type == "size_t")
+                    {
+                        CHECK(reader->NextArrayItem());
+                        size_t temp;
+                        reader->Read(&temp);
+                    }
+                    else
+                    {
+                        LOG(FATAL) << "cannot skip graph attr " << key;
+                    }
+                    CHECK(!reader->NextArrayItem());
+                }
+            }
+            CHECK_EQ(bitmask, 1 | 2 | 4) << "invalid format";
+        }
+    };
+
+    // The graph attribute fields.
+    void Load(dmlc::JSONReader* reader)
+    {
+        reader->BeginObject();
+        int bitmask = 0;
+        std::string key;
+        while (reader->NextObjectItem(&key))
+        {
+            if (key == "nodes")
+            {
+                reader->Read(&nodes_);
+                bitmask |= 1;
+            }
+            else if (key == "arg_nodes")
+            {
+                reader->Read(&input_nodes_);
+                bitmask |= 2;
+            }
+            else if (key == "node_row_ptr")
+            {
+                reader->Read(&node_row_ptr_);
+                bitmask |= 4;
+            }
+            else if (key == "heads")
+            {
+                reader->Read(&outputs_);
+                bitmask |= 8;
+            }
+            else if (key == "attrs")
+            {
+                reader->Read(&attrs_);
+                bitmask |= 16;
+            }
+            else
+            {
+                LOG(FATAL) << "key " << key << " is not supported";
+            }
+        }
+        CHECK_EQ(bitmask, 1 | 2 | 4 | 8 | 16) << "invalid format";
+    }
+
+    // Get node entry index.
+    uint32_t entry_id(uint32_t nid, uint32_t index) const
+    {
+        return node_row_ptr_[nid] + index;
+    }
+
+    // Get node entry index.
+    uint32_t entry_id(const NodeEntry& e) const
+    {
+        return entry_id(e.node_id, e.index);
+    }
+
+    // Number of node entries.
+    uint32_t num_node_entries() const
+    {
+        return node_row_ptr_.back();
+    }
+
+    /*! \brief The graph nodes. */
+    std::vector<Node> nodes_;
+    /*! \brief The argument nodes. */
+    std::vector<uint32_t> input_nodes_;
+    /*! \brief Used for quick entry indexing. */
+    std::vector<uint32_t> node_row_ptr_;
+    /*! \brief Output entries. */
+    std::vector<NodeEntry> outputs_;
+    /*! \brief Additional graph attributes. */
+    GraphAttr attrs_;
+    /*! \brief The code module that contains both host and device code. */
+    tvm::runtime::Module module_;
+    /*! \brief Execution context of all devices including the host. */
+    std::vector<TVMContext> ctxs_;
+    /*! \brief Common storage pool for all devices. */
+    std::vector<NDArray> storage_pool_;
+    /*! \brief Data entry of each node. */
+    std::vector<NDArray> data_entry_;
+};
+
+#endif // __graph_runtime_h__

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# tvm_cpp_test
-tvm cpp deploy experiments

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,377 @@
+Ubuntu
+------
+
+.. code-block:: none
+
+  > lsb_release -a
+  No LSB modules are available.
+  Distributor ID:  Ubuntu
+  Description:     Ubuntu 18.04.1 LTS
+  Release:         18.04
+  Codename:        bionic
+
+.. code-block:: none
+
+  > g++ --version
+  g++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
+  Copyright (C) 2017 Free Software Foundation, Inc.
+  This is free software; see the source for copying conditions.  There is NO
+  warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Packages
+--------
+
+Install the required system packages:
+
+.. code-block:: none
+
+    > sudo apt-get install -y \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    cmake \
+    curl \
+    git \
+    libatlas-base-dev \
+    libcurl4-openssl-dev \
+    libjemalloc-dev \
+    liblapack-dev \
+    libopenblas-dev \
+    libopencv-dev \
+    libzmq3-dev \
+    ninja-build \
+    software-properties-common \
+    sudo \
+    unzip \
+    wget \
+    libtinfo-dev \
+    zlib1g-dev
+
+Conda
+-----
+
+Install ``conda``:
+
+.. code-block:: none
+
+  [/dl]> wget https://repo.anaconda.com/archive/Anaconda3-5.3.1-Linux-x86_64.sh
+  [/dl]> chmod +x Anaconda3-5.3.1-Linux-x86_64.sh
+
+Run the ``*.sh`` script and set ``/dl/anaconda`` as an install destination:
+
+.. code-block:: none
+
+  [/dl]> ./Anaconda3-5.3.1-Linux-x86_64.sh
+
+Activate conda:
+
+.. code-block:: none
+
+  > source /dl/anaconda/etc/profile.d/conda.sh
+
+Test the installation (activate it first):
+
+.. code-block:: none
+
+  > conda list
+
+.. notes::
+
+  * https://conda.io/docs/user-guide/install/linux.html#installing-on-linux
+  * https://conda.io/docs/user-guide/install/test-installation.html
+
+Conda environment
+-----------------
+
+Load conda:
+
+.. code-block:: none
+
+  > source /dl/anaconda/etc/profile.d/conda.sh
+
+Check for existing environments:
+
+.. code-block:: none
+
+  > conda info --envs
+
+If ``dl`` environment is present and you want to remove it:
+
+.. code-block:: none
+
+  > conda remove --name dl --all
+
+Create a fresh dl environment for a reproducible test sandbox:
+
+.. code-block:: none
+
+  > conda create --name dl python=3.6
+
+Activate the environment: 
+
+.. code-block:: none
+
+  > conda activate dl
+  (dl)>
+
+.. note::
+
+  * https://conda.io/docs/user-guide/tasks/manage-environments.html
+
+Pip dependencies
+----------------
+
+Install the python dependencies using``pip``:
+
+.. code-block:: none
+
+  (dl)> pip install \
+      cpplint==1.3.0 \
+      h5py==2.8.0rc1 \
+      nose \
+      nose-timer \
+      'numpy<=1.15.2,>=1.8.2' \
+      pylint==1.8.3 \
+      'requests<2.19.0,>=2.18.4' \
+      scipy==1.0.1 \
+      boto3 \
+      decorator \
+      Pillow \
+      matplotlib
+
+There should be no ``mxnet`` or ``nnvm`` package installed on the system. Run a sanity check:
+
+.. code-block:: none
+
+  (dl)> python -c 'import mxnet'
+  Traceback (most recent call last):
+    File "<string>", line 1, in <module>
+  ModuleNotFoundError: No module named 'mxnet'
+
+.. code-block:: none
+
+  (dl)> python -c 'import nnvm'
+  Traceback (most recent call last):
+    File "<string>", line 1, in <module>
+  ModuleNotFoundError: No module named 'nnvm'
+
+MXNet
+-----
+
+Get the ``mxnet`` sources:
+
+.. code-block:: none
+
+  (dl)> cd /dl
+  (dl) [/dl]> git clone https://github.com/apache/incubator-mxnet mxnet
+  (dl) [/dl]> cd mxnet
+  (dl) [/dl/mxnet]>
+
+Lock the version:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet]> git branch test-1eb3344 1eb3344
+  (dl) [/dl/mxnet]> git checkout test-1eb3344
+  (dl) [/dl/mxnet]> git submodule update --init --recursive
+
+Run the ``mxnet`` build:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet]> cmake -H. -B_builds -DUSE_LAPACK=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DUSE_F16C=OFF
+  (dl) [/dl/mxnet]> cmake --build _builds -j $(nproc)
+
+Check the created ``libmxnet.so`` library:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet]> ls _builds/libmxnet.so
+
+We have to create a symbolic link, because that's where the Python code expects the library:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet]> mkdir -p lib
+  (dl) [/dl/mxnet]> ln -s /dl/mxnet/_builds/libmxnet.so /dl/mxnet/lib/libmxnet.so
+
+Test the import command:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet] > (PYTHONPATH=/dl/mxnet/python python -c 'import mxnet')
+
+.. note::
+
+  * https://mxnet.apache.org/install/ubuntu_setup.html#build-mxnet-from-source
+
+LLVM
+----
+
+LLVM is needed for the TVM build:
+
+.. code-block:: none
+
+  (dl) > cd /dl
+  (dl) [/dl]> wget http://releases.llvm.org/6.0.1/llvm-6.0.1.src.tar.xz
+  (dl) [/dl]> tar xf llvm-6.0.1.src.tar.xz
+  (dl) [/dl]> cmake -H/dl/llvm-6.0.1.src -B/dl/llvm-6.0.1.src/_builds -DCMAKE_INSTALL_PREFIX=/dl/llvm -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug
+  (dl) [/dl]> cmake --build /dl/llvm-6.0.1.src/_builds --target install -- -j $(nproc)
+
+TVM
+---
+
+Build TVM:
+
+.. code-block:: none
+
+  (dl) > cd /dl/mxnet/3rdparty/tvm
+  (dl) [/dl/mxnet/3rdparty/tvm]> cmake -H. -B_builds -DUSE_GRAPH_RUNTIME_DEBUG=ON -DUSE_CUDA=ON -DUSE_OPENCL=ON -DUSE_VULKAN=ON -DUSE_OPENGL=ON -DUSE_LLVM=/dl/llvm/bin/llvm-config -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug
+  (dl) [/dl/mxnet/3rdparty/tvm]> cmake --build _builds -- -j $(nproc)
+
+Check the library ``libtvm.so``:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet/3rdparty/tvm]> ls ./_builds/libtvm.so
+
+We have to create a symbolic link, because that's where Python code expects the libraries:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet/3rdparty/tvm]> mkdir -p lib nnvm/lib
+  (dl) [/dl/mxnet/3rdparty/tvm]> ln -s /dl/mxnet/3rdparty/tvm/_builds/libtvm.so /dl/mxnet/3rdparty/tvm/lib/libtvm.so
+  (dl) [/dl/mxnet/3rdparty/tvm]> ln -s /dl/mxnet/3rdparty/tvm/_builds/libnnvm_compiler.so /dl/mxnet/3rdparty/tvm/nnvm/lib/libnnvm_compiler.so
+
+Test the import command:
+
+.. code-block:: none
+
+  (dl) [/dl/mxnet/3rdparty/tvm]> (PYTHONPATH=/dl/mxnet/3rdparty/tvm/python:/dl/mxnet/3rdparty/tvm/topi/python:/dl/mxnet/3rdparty/tvm/nnvm/python python -c 'import nnvm')
+
+.. notes::
+
+  * https://docs.tvm.ai/install/from_source.html#build-the-shared-library
+  * https://docs.tvm.ai/install/from_source.html#python-package-installation
+
+OpenCL
+------
+
+The OpenCL setup described here can be skipped for the end-to-end Vulkan test.
+
+Install the OpenCL headers. For debian systems we can install OpenCL with ``apt-get``.
+
+If we are building for an Android device, we can download the lib directly from
+the device and grab the appropriate headers from the KhroosGroup site.
+
+.. code-block:: none
+
+  (dl) [/dl]> cd /dl
+  (dl) [/dl]> git clone https://github.com/KhronosGroup/OpenCL-Headers.git
+
+We must set ``CL_TARGET_OPENCL_VERSION`` appropriately to specify a particular version.
+
+* https://github.com/KhronosGroup/OpenCL-Headers#compiling-for-a-specific-opencl-version
+
+For OpenCL version 1.20 we would do the following:
+
+.. code-block:: none
+
+    #define CL_TARGET_OPENCL_VERSION 120
+    #include <CL/opencl.h>
+
+
+Android NDK
+-----------
+
+Here we install a recent Android NDK.
+First, we will use the NDK to build a standalone toolchain that provides a single
+compiler command for the TVM python build step
+(i.e., ``export TVM_NDK_CC=/dl/toolchains/android-toolchain-arm64/bin/aarch64-linux-android-clang++``)
+to produce our ``from_mxnet.so`` Android device inference library.
+Then we will use the NDK directly through our minimal CMake toolchain to cross compile
+the TMV inference application (``tvm_deploy_gpu_sample.cpp``) -- the thing that will
+open and run the generated ``from_mxnet.so`` library on the Android device using the
+``cat.bin`` file that was created from the ``cat.png`` in the python ``from_mxnet.py``
+scrip.
+
+.. code-block:: none
+
+    (dl) [/dl] > cd /dl
+    (dl) [/dl] > wget https://dl.google.com/android/repository/android-ndk-r18-linux-x86_64.zip
+    (dl) [/dl] > unzip android-ndk-r18-linux-x86_64.zip
+    (dl) [/dl] > cd /dl/android-ndk-r18/build/tools
+    (dl) [/dl/android-ndk-r18/build/tools] > ./make-standalone-toolchain.sh --platform=android-24 --use-llvm --arch=arm64 --install-dir=/dl/toolchains/android-toolchain-arm64	 
+
+
+The minimal NDK toolchain (``tvm_cpp_test/android.toolchain.cmake``) looks like this:
+
+.. code-block:: none
+
+    set(CMAKE_SYSTEM_NAME Android)
+    set(CMAKE_SYSTEM_VERSION 24) # API level
+    set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
+    set(CMAKE_ANDROID_NDK "${ndk_home}")
+    set(CMAKE_ANDROID_STL_TYPE c++_static)
+
+Details can be found in the official CMake documentation here
+`Cross Compiling for Android with the NDK <https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-android-with-the-ndk>`__
+
+
+from_mxnet.py
+-------------
+
+.. code-block:: none
+
+  (dl) > export OMP_NUM_THREADS=1
+
+We reduce the OMP threads with the above environment variable as a workaround
+for the following errors. This happens frequently enough in various tested
+configurations using TVM to warrant making this a default setup step, although
+it may not be necessary at some point in the future.
+
+.. code-block:: none
+
+  Assertion failure at kmp_runtime.cpp(6481): __kmp_team_pool == __null.
+  OMP: Error #13: Assertion failure at kmp_runtime.cpp(6481).
+
+.. code-block:: none
+
+  RuntimeError: Compilation error:
+  gcc: error trying to exec 'cc1plus': execvp: No such file or directory
+
+Clone the C++ test repository (``tvm_cpp_test``), compile with NNVM/TVM and run:
+
+.. code-block:: none
+
+  (dl) > cd /dl
+  (dl) [/dl]> git clone https://github.com/headupinclouds/tvm_cpp_test.git
+  (dl) [/dl]> cd tvm_cpp_test
+  (dl) [/dl/tvm_cpp_test]> source env.sh # set TVM_NDK_CC and PYTHONPATH
+  (dl) [/dl/tvm_cpp_test]> ./build-host.sh # reproduce host=target builds for all back-ends
+  (dl) [/dl/tvm_cpp_test]> ./build-android.sh # reproduce android vulkan failure
+
+
+When we run the final build-android.sh script above, an arm64 development device
+should be tethered to the host machine and accessible through ``adb``.  This build
+script will cross compile the C++ executable, install it on the device, and run
+inference on the centered cat image data.  It should report a max response at 282,
+but the Vulkan back-end on Android reports an inccorect result:
+
+.. code-block:: none
+
+    The maximum position in output vector is: 669
+    Expected 282 but got: 669
+
+Note that the curret example will hang at this point.  Presumably some tear down
+step is blocking on a thread or something similar.  To retrieve the results for
+comparison, it is necessary to kill the application and run the remainder
+of the script by hand manually to fetch the logged results.
+
+.. code-block:: none
+
+  (dl) > cd /dl/tvm_cpp_test
+  (dl) [/dl/tvm_cpp_test]> mkdir -p _results/ndk && cd _results/ndk && adb pull /data/local/tmp/vulkan
+  (dl) [/dl/tvm_cpp_test]> bash -fx ./cmp.sh # compare the android output with the ubuntu outputf
+
+The final ``cmp.sh`` script will ``diff`` ubuntu vs android vulkan output line by line.  By default, it output normalized differences > 0.1.

--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -1,0 +1,13 @@
+# See "Cross Compiling for Android with the NDK".
+# https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#id20  
+
+set(ndk_home "/dl/android-ndk-r18")
+if(NOT EXISTS ${ndk_home})
+  message(FATAL_ERROR "Please install NDK r18 in ${ndk_home}, see README.rst for details")
+endif()
+
+set(CMAKE_SYSTEM_NAME Android)
+set(CMAKE_SYSTEM_VERSION 24) # API level
+set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
+set(CMAKE_ANDROID_NDK "${ndk_home}")
+set(CMAKE_ANDROID_STL_TYPE c++_static)

--- a/build-android.sh
+++ b/build-android.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# https://discuss.tvm.ai/t/tvm-ndk-arm64-compile-without-rpc/65/3?u=headupinclouds
+#
+# if exec_gpu:
+#     # Mobile GPU
+#     target = 'opencl'
+#     target_host = "llvm -target=%s-linux-android" % arch
+# else:
+#     # Mobile CPU
+#     target = "llvm -target=%s-linux-android" % arch
+#     target_host = None
+
+set -e
+
+# See "Cross Compiling for Android with the NDK".
+# https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#id20  
+TOOLCHAIN=${PWD}/android.toolchain.cmake
+
+if [ -z "${TVM_NDK_CC}" ]; then
+    echo "Must set TVM_NDK_CC to point to vaid android compiler" 2>&1
+    exit 1
+fi
+
+cmake_args=(
+    -H.
+    -DCMAKE_VERBOSE_MAKEFILE=ON
+    -DCMAKE_BUILD_TYPE=Debug
+    -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}
+)
+
+platforms=(
+    # This reports the wrong result
+    "vulkan;vulkan;llvm -target=aarch64-linux-android"
+    # The Android CPU path works fine
+    "cpu;llvm -target=aarch64-linux-android;None"
+)
+
+exe_dir=/data/local/tmp
+
+for ((i=0; i < ${#platforms[@]}; i++)); do
+
+    IFS=';'; fields=(${platforms[i]}); unset IFS
+
+    flag="${fields[0]}"
+    target="${fields[1]}"
+    target_host="${fields[2]}"
+
+    echo "Test flag: ${flag}"
+    echo "Test target: ${target}"
+    echo "Test target host: ${target_host}"
+
+    # "detoxify" special characters for a clean dir name
+    toolchain_name=$(sed -E 's/( |-|=)/_/g' <<< "${target}")
+    target_dir=_builds/ndk/${toolchain_name}
+    target_upper=$(echo $flag | tr '[:lower:]' '[:upper:]')
+
+    # adb pull /system/vendor/lib64
+
+    mkdir -p ${target_dir}
+    [ -f ${target_dir}/CMakeCache.txt ] && rm ${target_dir}/CMakeCache.txt
+    cmake ${cmake_args[@]} -B${target_dir} -DTCT_USE_${target_upper}=ON && cmake --build ${target_dir}
+
+    pycmd="${PWD}/from_mxnet.py"
+
+    (
+	cd $target_dir
+	python ${pycmd} --target="${target}" --target-host="${target_host}"
+    )
+
+    exe_toolchain_dir=${exe_dir}/${toolchain_name}
+    adb push ${target_dir} ${exe_dir}
+    adb shell "cd ${exe_toolchain_dir} && ./tvm_deploy_gpu_sample \${PWD}/from_mxnet.so"
+
+    echo "adb pull output..."
+
+    result_dir=_results/ndk/
+    mkdir -p ${result_dir}
+    (
+	cd ${result_dir}
+	adb pull ${exe_toolchain_dir}
+    )
+
+    exit
+
+done

--- a/build-host.sh
+++ b/build-host.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+cmake_args=(
+    -H.
+    -DCMAKE_VERBOSE_MAKEFILE=ON
+    -DCMAKE_BUILD_TYPE=Debug
+)
+
+platforms=(
+    "vulkan;vulkan;None"
+    "cpu;llvm;None"
+    "cuda;cuda;None"
+    "opencl;opencl;None"
+    "opengl;opengl;None"
+    #"metal:metal"
+)
+
+#cmake ${cmake_args[@]} -DTCT_USE_OPENCL=1 && cmake --build _builds/
+
+for info in ${platforms[@]}; do
+
+    fields=(${info//;/ })
+    flag=${fields[0]}
+    target=${fields[1]}
+    target_host=${fields[2]}
+
+    target_dir=_builds/${target}
+    target_upper=$(echo $flag | tr '[:lower:]' '[:upper:]')
+
+    # Build the C++ executable:
+    mkdir -p ${target_dir}
+    #[ -f ${target_dir}/CMakeCache.txt ] && rm ${target_dir}/CMakeCache.txt
+    cmake ${cmake_args[@]} -B${target_dir} -DTCT_USE_${target_upper}=ON && cmake --build ${target_dir}
+
+    # Create the TVM shared library module:
+    pycmd="${PWD}/from_mxnet.py"
+    (
+	cd $target_dir
+	python ${pycmd} --target=${target} --target-host=${target_host}
+    	./tvm_deploy_gpu_sample ${PWD}/from_mxnet.so
+    )
+
+    exit
+done

--- a/cmp.sh
+++ b/cmp.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+find _results/ndk/vulkan/ -name "tvm*.txt" | sort | while read name_android;
+do
+    name=$(basename $name_android);
+    name_ubuntu=_builds/vulkan/${name};
+    paste -d' ' $name_android <(awk '{print $NF}' $name_ubuntu) | awk '{ s1=$(NF); s2=$(NF-1); d=(s1 > s2) ? (s1-s2) : (s2-s1); if(d/(s2+s1+1e-6f) > 0.1) { print " '$name' " NR " " $0 " " d } }';
+done 

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mxnet_dir=/dl/mxnet
+tvm_dir=${mxnet_dir}/3rdparty/tvm
+
+export PYTHONPATH=${mxnet_dir}/python:${tvm_dir}/python:${tvm_dir}/topi/python:${tvm_dir}/nnvm/python
+export TVM_NDK_CC=/dl/toolchains/android-toolchain-arm64/bin/aarch64-linux-android-clang++

--- a/from_mxnet.py
+++ b/from_mxnet.py
@@ -1,0 +1,222 @@
+"""
+.. _tutorial-from-mxnet:
+
+Compile MXNet Models
+====================
+**Author**: `Joshua Z. Zhang <https://zhreshold.github.io/>`_
+
+This article is an introductory tutorial to deploy mxnet models with NNVM.
+
+For us to begin with, mxnet module is required to be installed.
+
+A quick solution is
+
+.. code-block:: bash
+
+    pip install mxnet --user
+
+or please refer to offical installation guide.
+https://mxnet.incubator.apache.org/versions/master/install/index.html
+"""
+# some standard imports
+import mxnet as mx
+import nnvm
+import tvm
+import numpy as np
+
+import argparse
+
+target_table = [
+    'llvm',
+    'llvm -target=aarch64-linux-android',
+    'cuda',
+    'opengl',
+    'opencl',
+    'vulkan',
+    'metal'
+];
+
+description="""
+TVM from_mxnet tutorial with cross platform modifications\n
+"""
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=description
+)
+
+parser.add_argument(
+    '--target',
+    choices=[x for x in target_table],
+    help="Target device for inference step",
+)
+
+parser.add_argument(
+    '--target-host',
+    default=None,
+    help="Host device (cross platform usage)",
+)
+
+args = parser.parse_args()
+
+target = args.target
+target_host = None if (args.target_host == "None") else args.target_host
+
+# detect android cross compilation
+is_android = True if ('android' in (target + str(target_host))) else False
+
+print("is_android ", is_android)
+
+######################################################################
+# Download Resnet18 model from Gluon Model Zoo
+# ---------------------------------------------
+# In this section, we download a pretrained imagenet model and classify an image.
+from mxnet.gluon.model_zoo.vision import get_model
+from mxnet.gluon.utils import download
+from PIL import Image
+from matplotlib import pyplot as plt
+block = get_model('resnet18_v1', pretrained=True)
+img_name = 'cat.png'
+synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
+                      '4d0b62f3d01426887599d4f7ede23ee5/raw/',
+                      '596b27d23537e5a1b5751d2b0481ef172f58b539/',
+                      'imagenet1000_clsid_to_human.txt'])
+synset_name = 'synset.txt'
+download('https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true', img_name)
+download(synset_url, synset_name)
+with open(synset_name) as f:
+    synset = eval(f.read())
+image = Image.open(img_name).resize((224, 224))
+#plt.imshow(image)
+#plt.show()
+
+def transform_image(image):
+    image = np.array(image) - np.array([123., 117., 104.])
+    image /= np.array([58.395, 57.12, 57.375])
+    image = image.transpose((2, 0, 1))
+    image = image[np.newaxis, :]
+    return image
+
+x = transform_image(image)
+print('x', x.shape)
+
+######################################################################t
+# Compile the Graph
+# -----------------
+# Now we would like to port the Gluon model to a portable computational graph.
+# It's as easy as several lines.
+# We support MXNet static graph(symbol) and HybridBlock in mxnet.gluon
+sym, params = nnvm.frontend.from_mxnet(block)
+# we want a probability so add a softmax operator
+sym = nnvm.sym.softmax(sym)
+
+######################################################################
+# now compile the graph
+import nnvm.compiler
+
+print("target ", target)
+print("target_host ", target_host)
+
+shape_dict = {'data': x.shape}
+
+#    with tvm.build_config(unroll_explicit=False):
+
+with nnvm.compiler.build_config(opt_level=3):
+    graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params, target_host=target_host)
+
+# Export library (prepare for remote save/load, proof of concept)
+# https://docs.tvm.ai/api/python/module.html#tvm.module.Module.export_library
+
+#####################
+### serialization ###
+#####################
+
+params_bytes = nnvm.compiler.save_param_dict(params)
+with open('from_mxnet.params', 'bw') as f:
+  f.write(params_bytes)
+
+# https://docs.tvm.ai/api/python/nnvm/graph.html#nnvm.graph.Graph.json
+graph_json = graph.json()
+
+with open('from_mxnet.json', 'w') as f:
+  f.write(graph_json)
+
+with open('cat.bin', 'wb') as f:
+  f.write(x.astype(np.float32).tobytes())
+
+#print("source: ", lib.get_source())  
+
+if is_android:
+    lib.export_library('from_mxnet.so', tvm.contrib.ndk.create_shared, options=[
+        "-g",
+        "-shared",
+        "-fPIC",
+        "-nostdlib++"
+    ])
+
+    # TODO: we could enable the android rpc server for device testing in python
+    # skip inference step for cross compilation for now
+    exit()
+else:
+    lib.export_library('from_mxnet.so')
+
+
+    
+######################################################################
+# Execute the portable graph on TVM
+# ---------------------------------
+# Now, we would like to reproduce the same forward computation using TVM.
+from tvm.contrib import graph_runtime
+
+if target=='llvm':
+    ctx = tvm.cpu(0)
+elif target=='cuda':
+    ctx = tvm.gpu(0)
+elif target=='opengl':
+    ctx = tvm.opengl(0)
+elif target=='opencl':
+    ctx = tvm.cl(0)
+elif target=='vulkan':
+    ctx = tvm.vulkan(0)
+elif target=='metal':
+    ctx = tvm.metal(0)
+else:
+    raise ValueError('No supported context type for ' % target)
+
+dtype = 'float32'
+m = graph_runtime.create(graph, lib, ctx)
+# set inputs
+m.set_input('data', tvm.nd.array(x.astype(dtype)))
+m.set_input(**params)
+# execute
+m.run()
+# get outputs
+tvm_output = m.get_output(0)
+top1 = np.argmax(tvm_output.asnumpy()[0])
+print('TVM prediction top-1:', top1, synset[top1])
+
+######################################################################
+# Use MXNet symbol with pretrained weights
+# ----------------------------------------
+# MXNet often use `arg_prams` and `aux_params` to store network parameters
+# separately, here we show how to use these weights with existing API
+def block2symbol(block):
+    data = mx.sym.Variable('data')
+    sym = block(data)
+    args = {}
+    auxs = {}
+    for k, v in block.collect_params().items():
+        args[k] = mx.nd.array(v.data().asnumpy())
+    return sym, args, auxs
+mx_sym, args, auxs = block2symbol(block)
+# usually we would save/load it as checkpoint
+mx.model.save_checkpoint('resnet18_v1', 0, mx_sym, args, auxs)
+# there are 'resnet18_v1-0000.params' and 'resnet18_v1-symbol.json' on disk
+
+######################################################################
+# for a normal mxnet model, we start from here
+mx_sym, args, auxs = mx.model.load_checkpoint('resnet18_v1', 0)
+# now we use the same API to get NNVM compatible symbol
+nnvm_sym, nnvm_params = nnvm.frontend.from_mxnet(mx_sym, args, auxs)
+# repeat the same steps to run this model using TVM
+

--- a/tvm_deploy_gpu_sample.cpp
+++ b/tvm_deploy_gpu_sample.cpp
@@ -1,0 +1,308 @@
+#define TCT_SAVE_LAYERS 1
+#define TCT_TEST_DEBUG_GET_OUTPUT 0
+
+#include <string>
+#include <cstring>
+#include <fstream>
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+
+#include <dlpack/dlpack.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/runtime/packed_func.h>
+
+#if TCT_SAVE_LAYERS
+
+#include "GraphRuntime.h"
+
+#endif // TCT_SAVE_LAYERS
+
+// Iterator for N dimensional array
+inline void iterate(int dimensions, int64_t* ordinates, int64_t* maximums)
+{
+    for (int d = dimensions - 1; d >= 0; d--)
+    {
+        if ((ordinates[d]+1) < maximums[d])
+        {
+            ordinates[d]++;
+            break;
+        }
+
+        ordinates[d] = 0;
+    }
+}
+
+// Print DLTensor in flat diff friendly 'value[i,j,k...] = value' format:
+void print(DLTensor *layer_output, const std::vector<float> &values, std::ofstream &ofs)
+{
+    std::vector<int64_t> ord( layer_output->ndim , 0);
+    for (int k = 0; k < static_cast<int>(values.size()); k++)
+    {
+        std::stringstream index, shape;
+        for(int d = 0; d < ord.size(); d++)
+        {
+            index << ord[d];
+            shape << layer_output->shape[d];
+            if(d < ord.size()-1)
+            {
+                index << ", ";
+                shape << ", ";
+            }
+        }
+
+        std::stringstream ss;
+        ss  << "value"
+            << "["
+            << index.str()
+            << "] = "
+            << "{"
+            << shape.str()
+            << "} = "
+            << values[k]
+#if TUI_TEST_DEBUG_GET_OUTPUT
+            << " "
+            << values2[k]
+#endif
+          ;
+
+        ofs << ss.str() << std::endl;
+    }
+}
+
+int main(int argc, char** argv) try
+{
+    using Clock = std::chrono::high_resolution_clock;
+    using Timepoint = Clock::time_point;
+    using Duration = std::chrono::duration<double>;
+
+    if (argc < 2)
+    {
+        std::cerr << "usage: tvm_deploy_gpu_sample /full/path/to/from_mxnet.so " << std::endl;
+        return 1;
+    }
+
+    std::string lib = argv[1];
+
+    const std::string json_file("from_mxnet.json");
+    const std::string param_file("from_mxnet.params");
+    tvm::runtime::Module mod_syslib = tvm::runtime::Module::LoadFromFile(lib);
+
+#if TCT_SAVE_LAYERS
+    GraphRuntimePrivateStuff info;
+#endif
+
+    std::string json_data;
+    {
+        std::ifstream json_in(json_file.c_str(), std::ios::in);
+        if (!json_in)
+        {
+            std::cerr << "Failed to read json file " << json_file << std::endl;
+            return 1;
+        }
+
+#if TCT_SAVE_LAYERS
+        dmlc::JSONReader json(&json_in);
+        info.Load(&json);
+        json_in.clear();                 // clear fail and eof bits
+        json_in.seekg(0, std::ios::beg); // back to the start
+#endif
+
+        json_data.assign((std::istreambuf_iterator<char>(json_in)), std::istreambuf_iterator<char>());
+    }
+
+    std::string params_data;
+    {
+        std::ifstream params_in(param_file.c_str(), std::ios::binary);
+        if (!params_in)
+        {
+            std::cerr << "Failed to read param file " << param_file << std::endl;
+            return 1;
+        }
+
+        params_data.assign((std::istreambuf_iterator<char>(params_in)), std::istreambuf_iterator<char>());
+    }
+
+    TVMByteArray params_arr;
+    params_arr.data = params_data.data();
+    params_arr.size = params_data.length();
+
+    constexpr int dtype_code = kDLFloat;
+    constexpr int dtype_bits = 32;
+    constexpr int dtype_lanes = 1;
+
+    // If you receive an error stating "device_type
+#if defined(TVM_OPENCL_RUNTIME)
+    constexpr int device_type = kDLOpenCL;
+#elif defined(TVM_OPENGL_RUNTIME)
+    constexpr int device_type = 11; // kDLOpenGL;
+#elif defined(TVM_VULKAN_RUNTIME)
+    constexpr int device_type = kDLVulkan;
+#elif defined(TVM_METAL_RUNTIME)
+    constexpr int device_type = kDLMetal;
+#elif defined(TVM_CUDA_RUNTIME)
+    constexpr int device_type = kDLGPU;
+#elif defined(TVM_CPU_RUNTIME)
+    constexpr int device_type = kDLCPU;
+#else
+#  error Must define a valid TVM_<KIND>_RUNTIME flag, see CMakeLists.txt
+#endif
+
+    std::cout << "device_type " << int(device_type) << std::endl;
+
+    constexpr int device_id = 0;
+
+    //const char * runtime = "tvm.graph_runtime.create";
+    const char* runtime = "tvm.graph_runtime_debug.create";
+
+    tvm::runtime::Module mod = (*tvm::runtime::Registry::Get(runtime))(json_data, mod_syslib, device_type, device_id);
+
+    std::cout << "load_params" << std::endl;
+    tvm::runtime::PackedFunc load_params = mod.GetFunction("load_params");
+    load_params(params_arr);
+
+    DLTensor* x = nullptr;
+    DLTensor* y = nullptr;
+
+    const int n_samples = 1;
+
+    // Configure input tensor for single 1x3x224x224 RGB image (floating point)
+    const int in_ndim = 4;
+    const int64_t in_shape[] = { 1, 3, 224, 224 };
+    TVMArrayAlloc(in_shape, in_ndim, dtype_code, dtype_bits, dtype_lanes, device_type, device_id, &x);
+    const size_t in_size = in_shape[0] * in_shape[1] * in_shape[2] * in_shape[3];
+    std::vector<float> tvm_input(1 * in_size, 0);
+
+    // load image data saved in binary to tvm_input array
+    std::ifstream data_fin("cat.bin", std::ios::binary);
+    if (!data_fin)
+    {
+        std::cerr << "Failed to read input file cat.bin" << std::endl;
+        return 1;
+    }
+
+    data_fin.read(reinterpret_cast<char*>(tvm_input.data()), in_size * sizeof(float));
+
+    // Configure output tensor for 1x100 softmax class "probability" vector
+    const int out_ndim = 2;
+    const int64_t out_shape[] = { 1, 1000 };
+    TVMArrayAlloc(out_shape, out_ndim, dtype_code, dtype_bits, dtype_lanes, device_type, device_id, &y);
+    const size_t out_size = out_shape[0] * out_shape[1];
+    std::vector<float> tvm_output(1 * out_size, 0);
+
+    tvm::runtime::PackedFunc set_input = mod.GetFunction("set_input");
+    tvm::runtime::PackedFunc run = mod.GetFunction("run");
+    tvm::runtime::PackedFunc get_output = mod.GetFunction("get_output");
+    tvm::runtime::PackedFunc get_output_by_layer = mod.GetFunction("get_output_by_layer");
+#if TCT_TEST_DEBUG_GET_OUTPUT
+    tvm::runtime::PackedFunc debug_get_output = mod.GetFunction("debug_get_output");
+#endif
+
+    const int warmup = 10;
+
+    int count = 0;
+    double total = 0.0;
+    for (int i = 0; i < n_samples; ++i)
+    {
+        std::cout << "iteration " << i << std::endl;
+
+        std::cout << "set_input(data, x)" << std::endl;
+        TVMArrayCopyFromBytes(x, tvm_input.data(), in_size * sizeof(float));
+
+        set_input("data", x);
+
+        std::cout << "run()" << std::endl;
+        auto tic = Clock::now();
+        run();
+        auto toc = Clock::now();
+        auto elapsed = Duration(toc - tic).count();
+        if (i > warmup)
+        {
+            count++;
+            total += elapsed;
+            std::cout << "elapsed: " << elapsed << std::endl;
+        }
+
+        std::cout << "get_output(0, y)" << std::endl;
+        get_output(0, y);
+
+#if TCT_SAVE_LAYERS
+        for (int j = 0, k = 0; j < info.attrs_.shape.size(); j += 1, k++)
+        {
+            DLTensor* layer_output = nullptr;
+            DLTensor* layer_output2 = nullptr;
+
+            auto& shape = info.attrs_.shape[j];
+            auto code = info.attrs_.dltype;
+
+            std::size_t total = shape.front();
+            for (auto iter = shape.begin() + 1; iter != shape.end(); iter++)
+            {
+                total *= (*iter);
+            }
+
+            std::cout << "N=" << k << " total = " << total << std::endl;
+
+            std::cout << "get_output_by_layer(" << j << ", layer_output);" << std::endl;
+            std::vector<float> values(total);
+            layer_output = get_output_by_layer(j, 0);
+            TVMArrayCopyToBytes(layer_output, values.data(), values.size() * sizeof(float));
+
+#if TCT_TEST_DEBUG_GET_OUTPUT
+            // debug_get_output require pre-allocation:
+            TVMArrayAlloc(shape.data(), shape.size(), dtype_code, dtype_bits, dtype_lanes, device_type, device_id, &layer_output2);
+
+            std::cout << "debug_get_output(" << j << ", layer_output);" << std::endl;
+            auto result = debug_get_output(j, layer_output2);
+            std::vector<float> values2(total);
+            TVMArrayCopyToBytes(layer_output2, values2.data(), values2.size() * sizeof(float));
+            TVMArrayFree(layer_output2);
+#endif // TCT_TEST_DEBUG_GET_OUTPUT
+
+            std::stringstream ss;
+            ss << "tvm_" << std::setw(4) << std::setfill('0') << j << '_' << info.nodes_[j].name << ".txt";
+            std::ofstream ofs(ss.str());
+            if (ofs)
+            {
+    	        print(layer_output, values, ofs);
+            }
+        }
+#endif // TCT_SAVE_LAYERS
+
+        std::cout << "TVMArrayCopyToBytes(y, y_iter, out_size * sizeof(float));" << std::endl;
+        float* y_iter = tvm_output.data();
+        TVMArrayCopyToBytes(y, y_iter, out_size * sizeof(float));
+
+        for (std::size_t i = 0; i < tvm_output.size(); i++)
+        {
+            std::cout << "score[" << i << "] = " << tvm_output[i] << std::endl;
+        }
+
+        // get the maximum position in output vector
+        auto max_iter = std::max_element(y_iter, y_iter + 1000);
+        auto max_index = std::distance(y_iter, max_iter);
+        std::cout << "The maximum position in output vector is: " << max_index << std::endl;
+
+        if (max_index != 282) // 282: 'tiger cat' (see synset.txt)
+        {
+            std::cerr << "Expected 282 but got: " << max_index << std::endl;
+            exit(1);
+        }
+    }
+
+    TVMArrayFree(x);
+    TVMArrayFree(y);
+
+    std::cout << "average: " << total / static_cast<double>(count) << std::endl;
+
+    exit(0);
+}
+catch (const dmlc::Error& e)
+{
+    std::cerr << "error: " << e.what() << std::endl;
+}
+catch (const std::exception& e)
+{
+    std::cerr << "exception: " << e.what() << std::endl;
+}

--- a/tvm_runtime_pack.cc
+++ b/tvm_runtime_pack.cc
@@ -1,0 +1,77 @@
+/*!
+ * \brief This is an all in one TVM runtime file.
+ *
+ *   You only have to use this file to compile libtvm_runtime to
+ *   include in your project.
+ *
+ *  - Copy this file into your project which depends on tvm runtime.
+ *  - Compile with -std=c++11
+ *  - Add the following include path
+ *     - /path/to/tvm/include/
+ *     - /path/to/tvm/3rdparty/dmlc-core/include/
+ *     - /path/to/tvm/3rdparty/dlpack/include/
+ *   - Add -lpthread -ldl to the linked library.
+ *   - You are good to go.
+ *   - See the Makefile in the same folder for example.
+ *
+ *  The include files here are presented with relative path
+ *  You need to remember to change it to point to the right file.
+ *
+ */
+#include "../../src/runtime/c_runtime_api.cc"
+#include "../../src/runtime/cpu_device_api.cc"
+#include "../../src/runtime/workspace_pool.cc"
+#include "../../src/runtime/module_util.cc"
+#include "../../src/runtime/module.cc"
+#include "../../src/runtime/registry.cc"
+#include "../../src/runtime/file_util.cc"
+#include "../../src/runtime/threading_backend.cc"
+#include "../../src/runtime/thread_pool.cc"
+#include "../../src/runtime/ndarray.cc"
+
+// NOTE: all the files after this are optional modules
+// that you can include remove, depending on how much feature you use.
+
+// Likely we only need to enable one of the following
+// If you use Module::Load, use dso_module
+// For system packed library, use system_lib_module
+#include "../../src/runtime/dso_module.cc"
+#include "../../src/runtime/system_lib_module.cc"
+
+// Graph runtime
+#include "../../src/runtime/graph/graph_runtime.cc"
+
+#if defined(TVM_USE_GRAPH_RUNTIME_DEBUG)
+#  include "../../src/runtime/graph/debug/graph_runtime_debug.cc"
+#endif
+
+#if defined(TVM_USE_RPC)
+#  include "../../src/runtime/rpc/rpc_session.cc"
+#  include "../../src/runtime/rpc/rpc_event_impl.cc"
+#  include "../../src/runtime/rpc/rpc_server_env.cc"
+#endif
+
+#if defined(TVM_CUDA_RUNTIME)
+#  include "../../src/runtime/cuda/cuda_device_api.cc"
+#  include "../../src/runtime/cuda/cuda_module.cc"
+#endif
+
+#if defined(TVM_METAL_RUNTIME)
+#  include "../../src/runtime/metal/metal_device_api.mm"
+#  include "../../src/runtime/metal/metal_module.mm"
+#endif
+
+#if defined(TVM_OPENCL_RUNTIME)
+#  include "../../src/runtime/opencl/opencl_device_api.cc"
+#  include "../../src/runtime/opencl/opencl_module.cc"
+#endif
+
+#if defined(TVM_OPENGL_RUNTIME)
+#  include "../../src/runtime/opengl/opengl_device_api.cc"
+#  include "../../src/runtime/opengl/opengl_module.cc"
+#endif
+
+#if defined(TVM_VULKAN_RUNTIME)
+#  include "../../src/runtime/vulkan/vulkan_device_api.cc"
+#  include "../../src/runtime/vulkan/vulkan_module.cc"
+#endif


### PR DESCRIPTION
Initial commit with an end-to-end mxnet-to-tvm/nnvm example for android vulkan back-end debugging as described in issue https://github.com/dmlc/tvm/issues/2355

links:
* https://github.com/dmlc/tvm/issues/2355
* https://discuss.tvm.ai/t/vulkan-deploy-issue-with-latest-code/604/7?u=headupinclouds
* https://discuss.tvm.ai/t/huawei-p20-pro-vulkan-output-is-not-proper/702?u=headupinclouds

This repository aims to provide a reproducible test to serve as a basis for understanding the root cause of Vulkan back-end inference errors.  In particular, detailed steps are provided to walk through all required installation and test commands.  The C++ inference executable logs all all tensors layer-by-layer in a flattened line-by-line format to facilitate simple `diff` terminal analysis.  A final `cmp.sh` bash script can be run to illustrate differences between the output on the ubuntu (correct) and android (incorrect) targets.

* env setup
  + system deps (apt-get)
  + python/pip/conda
  + llvm
  + vulkan
  + mxnet
  + tvm
  + ndk
* use tvm/nnvm to build from_mxnet.so for target
* build tvm_deploy_gpu_sample.cpp for target
* push data to device and run + log layer by layer
* retrieve results and compare ubuntu vs android vulkan line-by-line